### PR TITLE
ChatSpace DB設計 構成確認

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
-# README
+# chat-space DB設計
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, unique: true|
+|password|string|null: false, unique: true|
+### Association
+- has_many :groups
+- has_many :chat_messages
 
-Things you may want to cover:
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+### Association
+- has_many :users, through: :groups_users
+- has_many :chat_messages
 
-* Ruby version
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- blongs_to :user
+- blongs_to :group
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## chat_messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|group_id|integer|null: false,foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 ### Association
-- has_many :groups
+- has_many :groups, through: :groups_users
 - has_many :chat_messages
 
 ## groupsテーブル

--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@
 |email|string|null: false, unique: true|
 |password|string|null: false, unique: true|
 ### Association
+- has_many :groups_users
 - has_many :groups, through: :groups_users
-- has_many :chat_messages
+- has_many :messages
+
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 ### Association
+- has_many :groups_users
 - has_many :users, through: :groups_users
-- has_many :chat_messages
+- has_many :messages
 
 ## groups_usersテーブル
 |Column|Type|Options|
@@ -27,10 +30,10 @@
 - blongs_to :user
 - blongs_to :group
 
-## chat_messagesテーブル
+## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |group_id|integer|null: false,foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|


### PR DESCRIPTION
# What
ChatSpace DB設計の構成をREADMEに記述する。
ユーザー管理　→　usersテーブル
グループ管理　→　groupsテーブル
チャットメッセージ管理　→　chat_messagesテーブル
上記３つが必要と考え、またユーザーとグループには多対多の関係があると考えた上、DB設計を行ました。

# Why
READMEはソフトウェアの使用や規格などを文書化したもの。まず、DBの設計から始めるため。